### PR TITLE
Fix Drawable LineChart Fill Bug

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -462,14 +462,25 @@ public class LineChartRenderer extends LineRadarRenderer {
         do {
             currentStartIndex = startingIndex + (iterations * indexInterval);
             currentEndIndex = currentStartIndex + indexInterval;
-            currentEndIndex = currentEndIndex > endingIndex ? endingIndex : currentEndIndex;
+            currentEndIndex = Math.min(currentEndIndex, endingIndex);
 
             if (currentStartIndex <= currentEndIndex) {
-                generateFilledPath(dataSet, currentStartIndex, currentEndIndex, filled);
+                final Drawable drawable = dataSet.getFillDrawable();
+
+                int startIndex = currentStartIndex;
+                int endIndex = currentEndIndex;
+
+                // Add a little extra to the path for drawables, larger data sets were showing space between adjacent drawables
+                if (drawable != null) {
+
+                    startIndex = Math.max(0, currentStartIndex - 1);
+                    endIndex = Math.min(endingIndex, currentEndIndex + 1);
+                }
+
+                generateFilledPath(dataSet, startIndex, endIndex, filled);
 
                 trans.pathValueToPixel(filled);
 
-                final Drawable drawable = dataSet.getFillDrawable();
                 if (drawable != null) {
 
                     drawFilledPath(c, filled, drawable);


### PR DESCRIPTION
The LineChart fill draws using intervals to avoid
memory issues, but with a larger data set and many
different (darker) colors Android does not draw the
drawable all the way to the edge of the interval.
This makes it look like there are spaces between the fill.
Draw a little beyond the existing interval so there are no gaps.

https://github.com/PhilJay/MPAndroidChart/pull/5284