### PR TITLE
Fix BarChartRenderer bug

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -71,6 +71,10 @@ public class BarChartRenderer extends BarLineScatterCandleBubbleRenderer {
     @Override
     public void drawData(Canvas c) {
 
+        if (mBarBuffers == null) {
+            initBuffers();
+        }
+
         BarData barData = mChart.getBarData();
 
         for (int i = 0; i < barData.getDataSetCount(); i++) {


### PR DESCRIPTION
Fixes NullPointerException in the BarChartRenderer. Adds a null check for mBarBuffers and calls initBuffers() if it is null.

This NPE was previously documented in [this issue](https://github.com/PhilJay/MPAndroidChart/issues/4151)