### PR TITLE
Add isFlingEnabled option to the chart

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -85,6 +85,11 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
     private boolean mScaleYEnabled = true;
 
     /**
+     * if true, fling gesture is enabled for the chart
+     */
+    private boolean mFlingEnabled = false;
+
+    /**
      * paint object for the (by default) lightgrey background of the grid
      */
     protected Paint mGridBackgroundPaint;
@@ -1167,6 +1172,22 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
 
     public boolean isScaleYEnabled() {
         return mScaleYEnabled;
+    }
+
+    /**
+     * Set this to true to enable fling gesture for the chart
+     *
+     * @param enabled
+     */
+    public void setFlingEnabled(boolean enabled) { this.mFlingEnabled = enabled; }
+
+    /**
+     * Returns true if fling gesture is enabled for the chart, false if not.
+     *
+     * @return
+     */
+    public boolean isFlingEnabled() {
+        return mFlingEnabled;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -108,7 +108,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
             }
         }
 
-        if (mTouchMode == NONE) {
+        if (mChart.isFlingEnabled()) {
             mGestureDetector.onTouchEvent(event);
         }
 


### PR DESCRIPTION
This fixes the issue seen in PhilJay#405. It adds an option to receive `OnChartGestureListener.onChartFling()` calls when the chart is zoomed in.