### PR TITLE
Fix isFlingEnabled bug

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -108,7 +108,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
             }
         }
 
-        if (mChart.isFlingEnabled()) {
+        if (mTouchMode == NONE || mChart.isFlingEnabled()) {
             mGestureDetector.onTouchEvent(event);
         }
 


### PR DESCRIPTION
I introduced a bug with #58. When a chart is zoomed in, it no longer recognizes single taps, so markers are not displaying. This PR re-introduces the original logic, with the added `isFlingEnabled` option. Apologies for not testing this thoroughly enough before. 